### PR TITLE
fix: Google Maps useLoadScript에서 libraries 타입 오류 수정

### DIFF
--- a/src/shared/components/AddressSearch.tsx
+++ b/src/shared/components/AddressSearch.tsx
@@ -10,6 +10,8 @@ interface AddressSearchProps {
   setDetailAddress: (val: string) => void;
 }
 
+const GOOGLE_MAP_LIBRARIES = ['places'] as ["places"];
+
 const AddressSearch = ({
     roadAddress,
     detailAddress,
@@ -22,7 +24,7 @@ const AddressSearch = ({
     const { setAddress } = useAddressStore();
     const { isLoaded } = useLoadScript({
       googleMapsApiKey: import.meta.env.VITE_GOOGLE_MAPS_API_KEY,
-      libraries: ['places'] as any,
+      libraries: GOOGLE_MAP_LIBRARIES,
     });
 
   // 도로명주소 자동완성 초기화


### PR DESCRIPTION
- 'libraries'에 ['places'] as ['places']로 고정 타입 지정
- string[] → Library[] 타입 불일치 해결
- 불필요한 LoadScript 재로딩 방지