### PR TITLE
[관리자] 매니저 목록 조회 방식 변경 및 매니저 신청 승인 / 거절 버튼 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@eslint/js": "^9.25.0",
         "@tailwindcss/vite": "^4.1.7",
         "@types/google.maps": "^3.58.1",
+        "@types/qs": "^6.14.0",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@types/react-router-dom": "^5.3.3",
@@ -2071,6 +2072,13 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@eslint/js": "^9.25.0",
     "@tailwindcss/vite": "^4.1.7",
     "@types/google.maps": "^3.58.1",
+    "@types/qs": "^6.14.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@types/react-router-dom": "^5.3.3",

--- a/src/features/admin/api/adminManager.ts
+++ b/src/features/admin/api/adminManager.ts
@@ -1,4 +1,5 @@
 import api from '@/services/axios';
+import qs from 'qs';
 
 // 전체 매니저 목록 조회
 export const fetchAdminManagers = async (params?: {
@@ -10,11 +11,15 @@ export const fetchAdminManagers = async (params?: {
   maxRating?: number;
   page?: number;
   size?: number;
+  excludeStatus?: string[];
 }) => {
   const cleanedParams = Object.fromEntries(
     Object.entries(params || {}).filter(([, value]) => value !== undefined && value !== "")
   );
-  const res = await api.get('/admin/managers', { params: cleanedParams });
+  const res = await api.get('/admin/managers', {
+    params: cleanedParams,
+    paramsSerializer: params => qs.stringify(params, { arrayFormat: 'repeat' }),
+  });
   console.log(res.data.body);
   if (!res.data.success) throw new Error(res.data.message || '매니저 목록 조회에 실패했습니다.');
   return res.data.body;
@@ -28,16 +33,16 @@ export const fetchAdminManagerById = async (managerId: string | number) => {
   return res.data.body;
 };
 
-// 신고된 매니저 목록 조회
-export const fetchSuspendedManagers = async () => {
-  const res = await api.get('/admin/managers/suspended');
-  if (!res.data.success) throw new Error(res.data.message || '신고된 매니저 목록 조회에 실패했습니다.');
+// 매니저 승인
+export const approveManager = async (managerId: number) => {
+  const res = await api.patch(`/admin/managers/applies/${managerId}`, { status: "ACTIVE" });
+  if (!res.data.success) throw new Error(res.data.message || '매니저 승인에 실패했습니다.');
   return res.data.body;
 };
 
-// 매니저 신청 내역 조회
-export const fetchAppliedManagers = async () => {
-  const res = await api.get('/admin/managers/applies');
-  if (!res.data.success) throw new Error(res.data.message || '매니저 신청 내역 조회에 실패했습니다.');
+// 매니저 거절
+export const rejectManager = async (managerId: number) => {
+  const res = await api.patch(`/admin/managers/applies/${managerId}`, { status: "REJECTED" });
+  if (!res.data.success) throw new Error(res.data.message || '매니저 거절에 실패했습니다.');
   return res.data.body;
 }; 

--- a/src/features/admin/pages/AdminManager/AdminManagerDetail.tsx
+++ b/src/features/admin/pages/AdminManager/AdminManagerDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import { fetchAdminManagerById } from "@/features/admin/api/adminManager";
+import { fetchAdminManagerById, approveManager, rejectManager } from "@/features/admin/api/adminManager";
 import type { AdminManagerDetail as AdminManagerDetailType } from "@/features/admin/types/AdminManagerType";
 
 export const AdminManagerDetail = () => {
@@ -29,6 +29,28 @@ export const AdminManagerDetail = () => {
   if (loading) return <div className="p-8">로딩 중...</div>;
   if (error) return <div className="p-8 text-red-500">{error}</div>;
   if (!manager) return null;
+
+  // 승인/거절 핸들러
+  const handleApprove = async () => {
+    if (!manager) return;
+    try {
+      await approveManager(manager.managerId);
+      alert('승인되었습니다.');
+      window.location.reload();
+    } catch (err: any) {
+      alert(err.message || '승인 실패');
+    }
+  };
+  const handleReject = async () => {
+    if (!manager) return;
+    try {
+      await rejectManager(manager.managerId);
+      alert('거절되었습니다.');
+      window.location.reload();
+    } catch (err: any) {
+      alert(err.message || '거절 실패');
+    }
+  };
 
   return (
     <div className="w-full flex flex-col">
@@ -115,13 +137,6 @@ export const AdminManagerDetail = () => {
             <div className="p-4 bg-slate-50 rounded-lg flex flex-col gap-1">
               <div className="text-slate-700 text-sm font-medium">주소: {manager.roadAddress}</div>
               <div className="text-slate-700 text-sm font-medium">상세주소: {manager.detailAddress}</div>
-            </div>
-          </div>
-          <div className="flex flex-col gap-2">
-            <div className="text-slate-500 text-base font-medium">경력</div>
-            <div className="p-4 bg-slate-50 rounded-lg flex flex-col gap-1">
-              <div className="text-slate-700 text-sm font-medium">- 클린하우스 전문 청소사 (2018-2023)</div>
-              <div className="text-slate-700 text-sm font-medium">- 홈클리닝 서비스 매니저 (2016-2018)</div>
             </div>
           </div>
           <div className="flex flex-col gap-2">
@@ -216,6 +231,22 @@ export const AdminManagerDetail = () => {
                 <div className="flex-1 text-slate-700 text-sm font-medium">{manager.terminationReason}</div>
               </div>
             </>
+          )}
+          {manager.status === 'PENDING' && (
+            <div className="flex gap-2 mt-4 justify-end">
+              <button
+                className="px-4 py-2 border border-indigo-600 text-indigo-600 rounded bg-white hover:bg-indigo-600 hover:text-white transition-colors"
+                onClick={handleApprove}
+              >
+                승인
+              </button>
+              <button
+                className="px-4 py-2 border border-red-500 text-red-500 rounded bg-white hover:bg-red-500 hover:text-white transition-colors"
+                onClick={handleReject}
+              >
+                거절
+              </button>
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
### 작업 내용
- 매니저 목록 조회 방식 변경
  - 특정 탭에서 원하는 매니저만 조회하기 위해 excludeStatus 리스트를 params에 추가해 조회
  - 기존에는 각 탭마다 다른 조회 매서드를 사용했지만 하나의 조회 메서트만 사용하도록 변경
 
- 검색 조건 초기화 오류 수정
  - 검색 조건이 탭이 바뀌어도 초기화 되지 않는 문제 수정

- 매니저 승인 / 거절 버튼 추가
  - 승인대기 상태의 매니저 상세 페이지에서 신청 승인 / 거절 버튼 추가