### PR TITLE
[Refactor] 매니저 페이지 카카오맵 연동

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded" rel="stylesheet" />
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined" rel="stylesheet">
   <script type="text/javascript" src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=ffc517f3fea1f918a5e4e30fd88d37d9&libraries=services&autoload=false"></script>
+  <script src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
 </head>
 
 <body>

--- a/src/features/manager/components/AddressMapCard.tsx
+++ b/src/features/manager/components/AddressMapCard.tsx
@@ -1,8 +1,86 @@
+import React, { useEffect, useRef, useState } from 'react'
+
+declare global {
+  interface Window {
+    kakao: unknown
+  }
+}
+
 export function AddressMapCard({ reservation }: { reservation: any }) {
+  const mapContainer = useRef<HTMLDivElement>(null)
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [hasError, setHasError] = useState<boolean>(false)
+  const address = reservation.roadAddress?.replace(/^대한민국\s+/, '') || ''
+  const detailAddress = reservation.detailAddress || ''
+  const fullAddress = `${address} ${detailAddress}`.trim()
+
+  useEffect(() => {
+    // 항상 오류가 발생해도 throw나 return 없이 진행
+    if (!fullAddress || !mapContainer.current) return
+    setIsLoading(true)
+    setHasError(false)
+
+    const initializeMap = () => {
+      try {
+        const kakao = window.kakao as any
+        if (!kakao || !kakao.maps) {
+          setHasError(true)
+          setIsLoading(false)
+          return
+        }
+        const mapOption = {
+          center: new kakao.maps.LatLng(37.5665, 126.978),
+          level: 6
+        }
+        const map = new kakao.maps.Map(mapContainer.current, mapOption)
+        const geocoder = new kakao.maps.services.Geocoder()
+        geocoder.addressSearch(fullAddress, (result: Array<{ x: string; y: string }>, status: string) => {
+          if (status === kakao.maps.services.Status.OK) {
+            const coords = new kakao.maps.LatLng(result[0].y, result[0].x)
+            map.setCenter(coords)
+            const marker = new kakao.maps.Marker({
+              map: map,
+              position: coords
+            })
+            const infoWindow = new kakao.maps.InfoWindow({
+              content: `<div style='padding:8px 12px;font-size:13px;'>${fullAddress}</div>`
+            })
+            infoWindow.open(map, marker)
+          } else {
+            setHasError(true)
+          }
+          setIsLoading(false)
+        })
+      } catch {
+        setHasError(true)
+        setIsLoading(false)
+      }
+    }
+    const kakao = window.kakao as any
+    if (kakao && kakao.maps) {
+      kakao.maps.load(() => {
+        initializeMap()
+      })
+    } else {
+      setTimeout(() => {
+        const kakao = window.kakao as any
+        if (kakao && kakao.maps) {
+          kakao.maps.load(() => {
+            initializeMap()
+          })
+        } else {
+          setHasError(true)
+          setIsLoading(false)
+        }
+      }, 1000)
+    }
+    // eslint-disable-next-line
+  }, [fullAddress])
+
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-3">
-        <div className="w-10 h-10 bg-green-100 rounded-full flex items-center justify-center">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-green-100">
           <svg className="w-5 h-5 text-green-600" fill="currentColor" viewBox="0 0 20 20">
             <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
           </svg>
@@ -11,34 +89,33 @@ export function AddressMapCard({ reservation }: { reservation: any }) {
       </div>
       <div className="bg-slate-50 rounded-lg border border-slate-200 overflow-hidden p-6 flex flex-col gap-4">
         <div className="mb-2">
-          {reservation.roadAddress && (
-            <p className="text-base text-slate-800 leading-relaxed">
-              {reservation.roadAddress.replace(/^대한민국\s+/, '')}
-            </p>
+          {address && (
+            <p className="text-base text-slate-800 leading-relaxed">{address}</p>
           )}
-          {reservation.detailAddress && (
-            <p className="text-sm text-slate-600">
-              상세주소: {reservation.detailAddress}
-            </p>
+          {detailAddress && (
+            <p className="text-sm text-slate-600">상세주소: {detailAddress}</p>
           )}
-          {!reservation.roadAddress && !reservation.detailAddress && (
+          {!address && !detailAddress && (
             <p className="text-slate-500">주소 정보가 없습니다.</p>
           )}
         </div>
-        {(reservation.roadAddress || reservation.detailAddress) ? (
-          <div className="-mx-6 md:-mx-8 lg:-mx-12 xl:-mx-16">
-            <iframe
-              src={`https://maps.google.com/maps?q=${encodeURIComponent(
-                (reservation.roadAddress?.replace(/^대한민국\s+/, '') || '') + ' ' + (reservation.detailAddress || '')
-              )}&output=embed`}
-              width="100%"
-              height="400"
-              style={{ border: 0, borderRadius: '12px' }}
-              allowFullScreen
-              loading="lazy"
-              referrerPolicy="no-referrer-when-downgrade"
-              title="서비스 위치"
+        {(address || detailAddress) ? (
+          <div className="-mx-6 md:-mx-8 lg:-mx-12 xl:-mx-16 relative">
+            <div
+              ref={mapContainer}
+              className="w-full h-[400px] rounded-[12px] bg-slate-100 border"
+              style={{ minHeight: 400 }}
             />
+            {isLoading && !hasError && (
+              <div className="absolute inset-0 flex items-center justify-center bg-gray-100 rounded-lg z-10">
+                <span className="text-gray-500 text-sm">지도를 불러오는 중...</span>
+              </div>
+            )}
+            {hasError && (
+              <div className="absolute inset-0 flex items-center justify-center bg-red-50 rounded-lg z-10">
+                <span className="text-red-500 text-base font-semibold">지도를 표시할 수 없습니다.</span>
+              </div>
+            )}
           </div>
         ) : (
           <div className="h-[400px] flex items-center justify-center bg-slate-100">
@@ -52,5 +129,5 @@ export function AddressMapCard({ reservation }: { reservation: any }) {
         )}
       </div>
     </div>
-  );
+  )
 } 

--- a/src/features/manager/components/AddressMapCard.tsx
+++ b/src/features/manager/components/AddressMapCard.tsx
@@ -13,9 +13,9 @@ export function AddressMapCard({ reservation }: { reservation: any }) {
   const address = reservation.roadAddress?.replace(/^대한민국\s+/, '') || ''
   const detailAddress = reservation.detailAddress || ''
   const fullAddress = `${address} ${detailAddress}`.trim()
+  const [centerCoords, setCenterCoords] = useState<{ lat: number; lng: number } | null>(null)
 
   useEffect(() => {
-    // 항상 오류가 발생해도 throw나 return 없이 진행
     if (!fullAddress || !mapContainer.current) return
     setIsLoading(true)
     setHasError(false)
@@ -36,7 +36,10 @@ export function AddressMapCard({ reservation }: { reservation: any }) {
         const geocoder = new kakao.maps.services.Geocoder()
         geocoder.addressSearch(fullAddress, (result: Array<{ x: string; y: string }>, status: string) => {
           if (status === kakao.maps.services.Status.OK) {
-            const coords = new kakao.maps.LatLng(result[0].y, result[0].x)
+            const lat = parseFloat(result[0].y)
+            const lng = parseFloat(result[0].x)
+            setCenterCoords({ lat, lng })
+            const coords = new kakao.maps.LatLng(lat, lng)
             map.setCenter(coords)
             const marker = new kakao.maps.Marker({
               map: map,
@@ -46,6 +49,26 @@ export function AddressMapCard({ reservation }: { reservation: any }) {
               content: `<div style='padding:8px 12px;font-size:13px;'>${fullAddress}</div>`
             })
             infoWindow.open(map, marker)
+            // 반경 5km 원 표시
+            const circle = new kakao.maps.Circle({
+              center: coords,
+              radius: 5000,
+              strokeWeight: 2,
+              strokeColor: '#6366f1',
+              strokeOpacity: 0.8,
+              strokeStyle: 'solid',
+              fillColor: '#6366f1',
+              fillOpacity: 0.1
+            })
+            circle.setMap(map)
+            // 원이 모두 보이도록 지도 bounds 조정
+            const bounds = new kakao.maps.LatLngBounds()
+            const earthRadius = 6371000
+            const deltaLat = ((5000 / earthRadius) * 180) / Math.PI
+            const deltaLng = ((5000 / (earthRadius * Math.cos((lat * Math.PI) / 180))) * 180) / Math.PI
+            bounds.extend(new kakao.maps.LatLng(lat + deltaLat, lng + deltaLng))
+            bounds.extend(new kakao.maps.LatLng(lat - deltaLat, lng - deltaLng))
+            map.setBounds(bounds)
           } else {
             setHasError(true)
           }
@@ -85,7 +108,7 @@ export function AddressMapCard({ reservation }: { reservation: any }) {
             <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
           </svg>
         </div>
-        <h2 className="text-xl font-bold text-slate-800">서비스 주소</h2>
+        <h2 className="text-xl font-bold text-slate-800">서비스 지역</h2>
       </div>
       <div className="bg-slate-50 rounded-lg border border-slate-200 overflow-hidden p-6 flex flex-col gap-4">
         <div className="mb-2">
@@ -103,8 +126,8 @@ export function AddressMapCard({ reservation }: { reservation: any }) {
           <div className="-mx-6 md:-mx-8 lg:-mx-12 xl:-mx-16 relative">
             <div
               ref={mapContainer}
-              className="w-full h-[400px] rounded-[12px] bg-slate-100 border"
-              style={{ minHeight: 400 }}
+              className="w-full h-[320px] rounded-[12px] bg-slate-100 border"
+              style={{ minHeight: 320 }}
             />
             {isLoading && !hasError && (
               <div className="absolute inset-0 flex items-center justify-center bg-gray-100 rounded-lg z-10">
@@ -118,13 +141,19 @@ export function AddressMapCard({ reservation }: { reservation: any }) {
             )}
           </div>
         ) : (
-          <div className="h-[400px] flex items-center justify-center bg-slate-100">
+          <div className="h-[320px] flex items-center justify-center bg-slate-100">
             <div className="text-center text-slate-500">
               <svg className="w-12 h-12 mx-auto mb-3 text-slate-400" fill="currentColor" viewBox="0 0 20 20">
                 <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
               </svg>
               <p className="text-sm">주소 정보가 없어 지도를 표시할 수 없습니다.</p>
             </div>
+          </div>
+        )}
+        {/* 안내문구 */}
+        {(address || detailAddress) && (
+          <div className="mt-2 text-sm text-slate-500">
+            지도에 표시된 위치를 중심으로 <span className="font-semibold text-indigo-600">반경 5km</span>가 서비스 지역입니다.
           </div>
         )}
       </div>

--- a/src/features/manager/pages/ManagerMy/ManagerMy.tsx
+++ b/src/features/manager/pages/ManagerMy/ManagerMy.tsx
@@ -1,11 +1,12 @@
-import { Fragment, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
-import { getManager } from "@/features/manager/api/managerMy";
-import type { ManagerInfo } from "@/features/manager/types/ManagerMyType";
-import { Loading } from "@/shared/components/ui/Loading";
-import ErrorToast from "@/shared/components/ui/toast/ErrorToast";
-import { Button } from "@/shared/components/ui/Button";
-import { Card } from "@/shared/components/ui/Card";
+import { Fragment, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { getManager } from '@/features/manager/api/managerMy'
+import type { ManagerInfo } from '@/features/manager/types/ManagerMyType'
+import { Loading } from '@/shared/components/ui/Loading'
+import ErrorToast from '@/shared/components/ui/toast/ErrorToast'
+import { Button } from '@/shared/components/ui/Button'
+import { Card } from '@/shared/components/ui/Card'
+import { AddressMapCard } from '@/features/manager/components/AddressMapCard'
 
 export const ManagerMy = () => {
   const [manager, setManager] = useState<ManagerInfo | null>(null);
@@ -14,10 +15,10 @@ export const ManagerMy = () => {
   useEffect(() => {
     const fetchManager = async () => {
       try {
-        const body = await getManager();
-        setManager(body);
+        const body = await getManager()
+        setManager(body)
       } catch {
-        setErrorToastMsg("매니저 정보 조회 중 오류가 발생하였습니다.");
+        setErrorToastMsg('매니저 정보 조회 중 오류가 발생하였습니다.')
       }
     };
     fetchManager();
@@ -30,7 +31,7 @@ export const ManagerMy = () => {
         <Loading />
         <ErrorToast
           open={!!errorToastMsg}
-          message={errorToastMsg || ""}
+          message={errorToastMsg || ''}
           onClose={() => setErrorToastMsg(null)}
         />
       </div>
@@ -41,20 +42,31 @@ export const ManagerMy = () => {
     <Fragment>
       <ErrorToast
         open={!!errorToastMsg}
-        message={errorToastMsg || ""}
+        message={errorToastMsg || ''}
         onClose={() => setErrorToastMsg(null)}
       />
-      <div className="max-w-4xl mx-auto py-10 px-4 flex flex-col gap-8">
+      <div className="mx-auto flex max-w-4xl flex-col gap-8 px-4 py-10">
+        {/* 상단 우측 정보 수정 버튼 */}
+        <div className="mb-4 flex justify-end">
+          <Link
+            to="/managers/my/edit"
+            className="flex h-10 items-center rounded bg-indigo-600 px-5 font-semibold text-white transition hover:bg-indigo-700"
+          >
+            정보 수정
+          </Link>
+        </div>
         {/* 1. 프로필/상태 */}
-        <Card className="p-6 flex flex-col items-center gap-3 bg-white shadow rounded-xl">
+        <Card className="flex flex-col items-center gap-3 rounded-xl bg-white p-6 shadow">
           {/* 프로필 이미지/이니셜 */}
-          <div className="w-20 h-20 rounded-full bg-indigo-100 flex items-center justify-center text-3xl font-bold text-indigo-600 mb-2">
-            {manager.userName?.charAt(0) || "?"}
+          <div className="mb-2 flex h-20 w-20 items-center justify-center rounded-full bg-indigo-100 text-3xl font-bold text-indigo-600">
+            {manager.userName?.charAt(0) || '?'}
           </div>
           {/* 이름 + 상태 뱃지 */}
           <div className="flex items-center gap-2">
-            <span className="text-xl font-bold text-slate-800">{manager.userName}</span>
-            <span className={`px-2 py-0.5 rounded text-xs font-semibold ${manager.status === 'ACTIVE' ? 'bg-green-100 text-green-700' : 'bg-gray-200 text-gray-500'}`}>
+            <span className="text-xl font-bold text-slate-800">
+              {manager.userName}
+            </span>
+            <span className={`rounded px-2 py-0.5 text-xs font-semibold ${manager.status === 'ACTIVE' ? 'bg-green-100 text-green-700' : 'bg-gray-200 text-gray-500'}`}>
               {manager.statusName}
             </span>
           </div>
@@ -82,58 +94,19 @@ export const ManagerMy = () => {
         </Card>
 
         {/* 2. 서비스 지역(주소+지도) */}
-        <Card className="bg-white border border-gray-200 shadow-md rounded-xl p-6 flex flex-col gap-4">
-          <div className="flex items-center gap-3 mb-2">
-            <span className="material-symbols-outlined text-indigo-500">
-              location_on
-            </span>
-            <span className="text-lg font-bold text-slate-800">
-              서비스 지역
-            </span>
-          </div>
-          {manager.roadAddress ? (
-            <>
-              <div className="text-base text-slate-700 font-medium">
-                {manager.roadAddress}
-                {manager.detailAddress && (
-                  <span className="text-slate-500 ml-1">
-                    {manager.detailAddress}
-                  </span>
-                )}
-              </div>
-              <div className="rounded-lg overflow-hidden border border-slate-200">
-                <iframe
-                  src={`https://maps.google.com/maps?q=${encodeURIComponent(
-                    (manager.roadAddress?.replace(/^대한민국\s+/, "") || "") +
-                    " " +
-                    (manager.detailAddress || ""),
-                  )}&z=14&output=embed`}
-                  width="100%"
-                  height="320"
-                  style={{ border: 0, borderRadius: "12px" }}
-                  allowFullScreen
-                  loading="lazy"
-                  referrerPolicy="no-referrer-when-downgrade"
-                  title="서비스 위치"
-                />
-              </div>
-              <div className="text-sm text-slate-500 mt-2">
-                지도에 표시된 위치를 중심으로
-                <span className="font-semibold text-indigo-600">반경 5km</span>
-                가 서비스 지역입니다.
-              </div>
-            </>
-          ) : (
-            <div className="text-slate-400 text-base">
-              주소 정보가 없어 서비스 지역 지도를 표시할 수 없습니다.
-            </div>
-          )}
+        <Card className="flex flex-col gap-4 rounded-xl border border-gray-200 bg-white p-6 shadow-md">
+          <AddressMapCard
+            reservation={{
+              roadAddress: manager.roadAddress,
+              detailAddress: manager.detailAddress
+            }}
+          />
         </Card>
 
         {/* 3. 첨부파일 */}
         {manager.fileId && (
-          <Card className="p-6 flex flex-col gap-2">
-            <div className="text-base font-semibold text-slate-800 mb-2">
+          <Card className="flex flex-col gap-2 p-6">
+            <div className="mb-2 text-base font-semibold text-slate-800">
               첨부파일
             </div>
             <div className="flex items-center gap-2">
@@ -148,7 +121,7 @@ export const ManagerMy = () => {
               >
                 {manager.fileName}
               </a> */}
-              <span className="text-slate-700 text-sm font-medium">
+              <span className="text-sm font-medium text-slate-700">
                 {manager.fileName}
               </span>
             </div>
@@ -156,9 +129,9 @@ export const ManagerMy = () => {
         )}
 
         {/* 4. 계약 정보 */}
-        <Card className="bg-white border border-indigo-200 shadow-lg rounded-2xl p-8 flex flex-col gap-4">
-          <div className="flex items-center gap-3 mb-3">
-            <span className="material-symbols-outlined text-indigo-500 text-2xl">
+        <Card className="flex flex-col gap-4 rounded-2xl border border-indigo-200 bg-white p-8 shadow-lg">
+          <div className="mb-3 flex items-center gap-3">
+            <span className="material-symbols-outlined text-2xl text-indigo-500">
               gavel
             </span>
             <span className="text-xl font-bold text-slate-800">계약 정보</span>
@@ -168,39 +141,39 @@ export const ManagerMy = () => {
               <span className="w-32 font-medium text-slate-500">계약 상태</span>
               <span className="flex items-center">
                 <span className="mr-2">
-                  <Button className="px-3 py-1 text-xs font-medium cursor-default bg-indigo-100 text-indigo-700">
+                  <Button className="cursor-default bg-indigo-100 px-3 py-1 text-xs font-medium">
                     {manager.statusName}
                   </Button>
                 </span>
               </span>
             </div>
-            {manager.status === "ACTIVE" && (
+            {manager.status === 'ACTIVE' && (
               <div className="flex items-center gap-3">
                 <span className="w-32 font-medium text-slate-500">
                   계약 시작일
                 </span>
-                <span className="text-slate-700 text-sm font-medium">
+                <span className="text-sm font-medium text-slate-700">
                   {manager.contractAt}
                 </span>
               </div>
             )}
-            {manager.status === "TERMINATION_PENDING" && (
+            {manager.status === 'TERMINATION_PENDING' && (
               <div className="flex flex-col gap-2">
                 <div className="w-32 font-medium text-slate-500">
                   계약 해지 사유
                 </div>
-                <div className="rounded-lg bg-red-50 p-4 text-sm font-medium text-red-700 whitespace-pre-wrap">
+                <div className="rounded-lg bg-red-50 p-4 text-sm font-medium whitespace-pre-wrap text-red-700">
                   {manager.terminationReason}
                 </div>
               </div>
             )}
-            {manager.status === "ACTIVE" && (
-              <div className="flex justify-end mt-4">
+            {manager.status === 'ACTIVE' && (
+              <div className="mt-4 flex justify-end">
                 <Link
                   to="/managers/my/contract-cancel"
                   state={{
                     contractAt: manager.contractAt,
-                    statusName: manager.statusName,
+                    statusName: manager.statusName
                   }}
                 >
                   <Button className="h-10 w-40 bg-red-500 hover:bg-red-600 text-white font-semibold rounded-lg shadow">


### PR DESCRIPTION
## ✅ 작업 유형

- [x] ♻️ 리팩토링 (Refactor)

---

## 🔍 작업 내용
- 매니저 페이지 중 지도 정보를 사용하는 페이지에서 구글맵을 카카오맵으로 대체
  - 매니저 예약 상세 페이지
  - 매니저 마이페이지
  - 매니저 정보 수정 페이지

---

## 💬 리뷰요청
- 매니저 페이지에서 구글맵을 카카오맵으로 수정했습니다.
- 주소 체계가 달라져 기존 DB에 있는 구글맵 주소체계는 카카오맵에서 사용할 수 없는 문제가 있습니다.
- 위도, 경도는 소수점 13자리까지 나와 7자리까지 반올림해야하는 이슈가 있습니다.

---

## 📎 관련 이슈
Closes #154 

