### PR TITLE
[Fix] 매니저 페이지 카카오맵 연동 중 빌드 오류 수정

### DIFF
--- a/src/features/admin/components/ManagerAddressMap.tsx
+++ b/src/features/admin/components/ManagerAddressMap.tsx
@@ -2,15 +2,8 @@ import React, { useEffect, useRef } from "react";
 import Loading from "@/shared/components/ui/Loading";
 
 interface ManagerAddressMapProps {
-  address: string;
-  detailAddress: string;
-}
-
-// 카카오 맵 API 타입 정의
-declare global {
-  interface Window {
-    kakao: any;
-  }
+  address: string
+  detailAddress: string
 }
 
 const ManagerAddressMap: React.FC<ManagerAddressMapProps> = ({
@@ -19,55 +12,57 @@ const ManagerAddressMap: React.FC<ManagerAddressMapProps> = ({
 }) => {
   const mapContainer = useRef<HTMLDivElement>(null);
   const mapRef = useRef<any>(null);
-  const [isLoading, setIsLoading] = React.useState(true);
-  const [hasError, setHasError] = React.useState(false);
+  const [isLoading, setIsLoading] = React.useState(true)
+  const [hasError, setHasError] = React.useState(false)
 
   useEffect(() => {
     const initializeMap = () => {
       if (!mapContainer.current) {
-        setHasError(true);
-        setIsLoading(false);
-        return;
+        setHasError(true)
+        setIsLoading(false)
+        return
       }
 
       if (!window.kakao || !window.kakao.maps) {
-        setHasError(true);
-        setIsLoading(false);
-        return;
+        setHasError(true)
+        setIsLoading(false)
+        return
       }
 
       try {
+        // kakao.maps를 any로 우회
+        const maps = (window.kakao as any).maps
         // 지도 초기화
         const mapOption = {
-          center: new window.kakao.maps.LatLng(37.5665, 126.978), // 서울 중심
+          center: new maps.LatLng(37.5665, 126.978), // 서울 중심
           level: 6, // 지도 확대 레벨
         };
 
-        const map = new window.kakao.maps.Map(mapContainer.current, mapOption);
+        const map = new maps.Map(mapContainer.current, mapOption);
         mapRef.current = map;
 
         // 주소-좌표 변환 객체 생성
-        const geocoder = new window.kakao.maps.services.Geocoder();
+        const geocoder = new maps.services.Geocoder();
 
         // 주소로 좌표 검색
-        geocoder.addressSearch(address, (result: any, status: any) => {
-          if (status === window.kakao.maps.services.Status.OK) {
-            const coords = new window.kakao.maps.LatLng(
+        geocoder.addressSearch(address, (result: any[], status: string) => {
+          if (status === maps.services.Status.OK) {
+            const coords = new maps.LatLng(
               result[0].y,
-              result[0].x,
-            );
+              result[0].x
+            )
 
             // 지도 중심을 검색된 좌표로 이동
             map.setCenter(coords);
 
             // 마커 생성
-            const marker = new window.kakao.maps.Marker({
+            const marker = new maps.Marker({
               map: map,
               position: coords,
             });
 
             // 정보창 생성
-            const infoWindow = new window.kakao.maps.InfoWindow({
+            const infoWindow = new maps.InfoWindow({
               content: `
                 <div style="padding: 10px; min-width: 200px;">
                   <div style="font-weight: bold; margin-bottom: 5px;">매니저 위치</div>
@@ -83,7 +78,7 @@ const ManagerAddressMap: React.FC<ManagerAddressMapProps> = ({
             infoWindow.open(map, marker);
 
             // 서비스 가능 지역 원 표시 (반경 5km)
-            const circle = new window.kakao.maps.Circle({
+            const circle = new maps.Circle({
               center: coords,
               radius: 5000, // 5km
               strokeWeight: 2,
@@ -97,7 +92,7 @@ const ManagerAddressMap: React.FC<ManagerAddressMapProps> = ({
             circle.setMap(map);
 
             // 원이 모두 보이도록 지도 레벨 조정
-            const bounds = new window.kakao.maps.LatLngBounds();
+            const bounds = new maps.LatLngBounds();
             const distance = 5000; // 5km
             const earthRadius = 6371000; // 지구 반지름 (미터)
 
@@ -111,10 +106,10 @@ const ManagerAddressMap: React.FC<ManagerAddressMapProps> = ({
               Math.PI;
 
             bounds.extend(
-              new window.kakao.maps.LatLng(lat + deltaLat, lng + deltaLng),
+              new maps.LatLng(lat + deltaLat, lng + deltaLng),
             );
             bounds.extend(
-              new window.kakao.maps.LatLng(lat - deltaLat, lng - deltaLng),
+              new maps.LatLng(lat - deltaLat, lng - deltaLng),
             );
 
             map.setBounds(bounds);
@@ -133,14 +128,14 @@ const ManagerAddressMap: React.FC<ManagerAddressMapProps> = ({
     // 카카오 맵 API가 이미 로드되어 있으면 바로 초기화
     if (window.kakao && window.kakao.maps) {
       // autoload=false이므로 수동으로 로드
-      window.kakao.maps.load(() => {
+      (window.kakao as any).maps.load(() => {
         initializeMap();
       });
     } else {
       // 약간의 지연 후 재시도
       const timer = setTimeout(() => {
         if (window.kakao && window.kakao.maps) {
-          window.kakao.maps.load(() => {
+          (window.kakao as any).maps.load(() => {
             initializeMap();
           });
         } else {

--- a/src/features/manager/components/AddressMapCard.tsx
+++ b/src/features/manager/components/AddressMapCard.tsx
@@ -1,19 +1,18 @@
-import React, { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
-declare global {
-  interface Window {
-    kakao: unknown
+export function AddressMapCard(
+  {
+    reservation
+  }: {
+    reservation: { roadAddress?: string; detailAddress?: string }
   }
-}
-
-export function AddressMapCard({ reservation }: { reservation: any }) {
+) {
   const mapContainer = useRef<HTMLDivElement>(null)
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [hasError, setHasError] = useState<boolean>(false)
   const address = reservation.roadAddress?.replace(/^대한민국\s+/, '') || ''
   const detailAddress = reservation.detailAddress || ''
   const fullAddress = `${address} ${detailAddress}`.trim()
-  const [centerCoords, setCenterCoords] = useState<{ lat: number; lng: number } | null>(null)
 
   useEffect(() => {
     if (!fullAddress || !mapContainer.current) return
@@ -22,73 +21,77 @@ export function AddressMapCard({ reservation }: { reservation: any }) {
 
     const initializeMap = () => {
       try {
-        const kakao = window.kakao as any
-        if (!kakao || !kakao.maps) {
+        const maps = (window.kakao as unknown as { maps: any }).maps
+        if (!maps) {
           setHasError(true)
           setIsLoading(false)
           return
         }
         const mapOption = {
-          center: new kakao.maps.LatLng(37.5665, 126.978),
+          center: new maps.LatLng(37.5665, 126.978),
           level: 6
         }
-        const map = new kakao.maps.Map(mapContainer.current, mapOption)
-        const geocoder = new kakao.maps.services.Geocoder()
-        geocoder.addressSearch(fullAddress, (result: Array<{ x: string; y: string }>, status: string) => {
-          if (status === kakao.maps.services.Status.OK) {
-            const lat = parseFloat(result[0].y)
-            const lng = parseFloat(result[0].x)
-            setCenterCoords({ lat, lng })
-            const coords = new kakao.maps.LatLng(lat, lng)
-            map.setCenter(coords)
-            const marker = new kakao.maps.Marker({
-              map: map,
-              position: coords
-            })
-            const infoWindow = new kakao.maps.InfoWindow({
-              content: `<div style='padding:8px 12px;font-size:13px;'>${fullAddress}</div>`
-            })
-            infoWindow.open(map, marker)
-            // 반경 5km 원 표시
-            const circle = new kakao.maps.Circle({
-              center: coords,
-              radius: 5000,
-              strokeWeight: 2,
-              strokeColor: '#6366f1',
-              strokeOpacity: 0.8,
-              strokeStyle: 'solid',
-              fillColor: '#6366f1',
-              fillOpacity: 0.1
-            })
-            circle.setMap(map)
-            // 원이 모두 보이도록 지도 bounds 조정
-            const bounds = new kakao.maps.LatLngBounds()
-            const earthRadius = 6371000
-            const deltaLat = ((5000 / earthRadius) * 180) / Math.PI
-            const deltaLng = ((5000 / (earthRadius * Math.cos((lat * Math.PI) / 180))) * 180) / Math.PI
-            bounds.extend(new kakao.maps.LatLng(lat + deltaLat, lng + deltaLng))
-            bounds.extend(new kakao.maps.LatLng(lat - deltaLat, lng - deltaLng))
-            map.setBounds(bounds)
-          } else {
-            setHasError(true)
+        const map = new maps.Map(mapContainer.current, mapOption)
+        const geocoder = new maps.services.Geocoder()
+        geocoder.addressSearch(
+          fullAddress,
+          (result: Array<{ x: string; y: string }>, status: string) => {
+            if (status === maps.services.Status.OK) {
+              const lat = parseFloat(result[0].y)
+              const lng = parseFloat(result[0].x)
+              const coords = new maps.LatLng(lat, lng)
+              map.setCenter(coords)
+              const marker = new maps.Marker({
+                map: map,
+                position: coords
+              })
+              const infoWindow = new maps.InfoWindow({
+                content: `<div style='padding:8px 12px;font-size:13px;'>${fullAddress}</div>`
+              })
+              infoWindow.open(map, marker)
+              // 반경 5km 원 표시
+              const circle = new maps.Circle({
+                center: coords,
+                radius: 5000,
+                strokeWeight: 2,
+                strokeColor: '#6366f1',
+                strokeOpacity: 0.8,
+                strokeStyle: 'solid',
+                fillColor: '#6366f1',
+                fillOpacity: 0.1
+              })
+              circle.setMap(map)
+              // 원이 모두 보이도록 지도 bounds 조정
+              const bounds = new maps.LatLngBounds()
+              const earthRadius = 6371000
+              const deltaLat = ((5000 / earthRadius) * 180) / Math.PI
+              const deltaLng =
+                ((5000 / (earthRadius * Math.cos((lat * Math.PI) / 180))) * 180) /
+                Math.PI
+              bounds.extend(new maps.LatLng(lat + deltaLat, lng + deltaLng))
+              bounds.extend(new maps.LatLng(lat - deltaLat, lng - deltaLng))
+              map.setBounds(bounds)
+            } else {
+              setHasError(true)
+            }
+            setIsLoading(false)
           }
-          setIsLoading(false)
-        })
+        )
       } catch {
         setHasError(true)
         setIsLoading(false)
       }
     }
-    const kakao = window.kakao as any
-    if (kakao && kakao.maps) {
-      kakao.maps.load(() => {
+    const maps = (window.kakao as unknown as { maps: any }).maps
+    if (maps) {
+      maps.load(() => {
         initializeMap()
       })
     } else {
       setTimeout(() => {
-        const kakao = window.kakao as any
-        if (kakao && kakao.maps) {
-          kakao.maps.load(() => {
+        const maps = (window.kakao as unknown as { maps: any }).maps
+        if (maps) {
+          maps.load(() => {
             initializeMap()
           })
         } else {
@@ -104,16 +107,24 @@ export function AddressMapCard({ reservation }: { reservation: any }) {
     <div className="space-y-6">
       <div className="flex items-center gap-3">
         <div className="flex h-10 w-10 items-center justify-center rounded-full bg-green-100">
-          <svg className="w-5 h-5 text-green-600" fill="currentColor" viewBox="0 0 20 20">
-            <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
+          <svg
+            className="h-5 w-5 text-green-600"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+          >
+            <path
+              fillRule="evenodd"
+              d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
+              clipRule="evenodd"
+            />
           </svg>
         </div>
         <h2 className="text-xl font-bold text-slate-800">서비스 지역</h2>
       </div>
-      <div className="bg-slate-50 rounded-lg border border-slate-200 overflow-hidden p-6 flex flex-col gap-4">
+      <div className="flex flex-col gap-4 overflow-hidden rounded-lg border border-slate-200 bg-slate-50 p-6">
         <div className="mb-2">
           {address && (
-            <p className="text-base text-slate-800 leading-relaxed">{address}</p>
+            <p className="leading-relaxed text-slate-800">{address}</p>
           )}
           {detailAddress && (
             <p className="text-sm text-slate-600">상세주소: {detailAddress}</p>
@@ -122,38 +133,50 @@ export function AddressMapCard({ reservation }: { reservation: any }) {
             <p className="text-slate-500">주소 정보가 없습니다.</p>
           )}
         </div>
-        {(address || detailAddress) ? (
-          <div className="-mx-6 md:-mx-8 lg:-mx-12 xl:-mx-16 relative">
+        {address || detailAddress ? (
+          <div className="relative -mx-6 md:-mx-8 lg:-mx-12 xl:-mx-16">
             <div
               ref={mapContainer}
-              className="w-full h-[320px] rounded-[12px] bg-slate-100 border"
+              className="h-[320px] w-full rounded-[12px] border bg-slate-100"
               style={{ minHeight: 320 }}
             />
             {isLoading && !hasError && (
-              <div className="absolute inset-0 flex items-center justify-center bg-gray-100 rounded-lg z-10">
-                <span className="text-gray-500 text-sm">지도를 불러오는 중...</span>
+              <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-gray-100">
+                <span className="sm text-gray-500">지도를 불러오는 중...</span>
               </div>
             )}
             {hasError && (
-              <div className="absolute inset-0 flex items-center justify-center bg-red-50 rounded-lg z-10">
-                <span className="text-red-500 text-base font-semibold">지도를 표시할 수 없습니다.</span>
+              <div className="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-red-50">
+                <span className="base font-semibold text-red-500">
+                  지도를 표시할 수 없습니다.
+                </span>
               </div>
             )}
           </div>
         ) : (
-          <div className="h-[320px] flex items-center justify-center bg-slate-100">
+          <div className="flex h-[320px] items-center justify-center bg-slate-100">
             <div className="text-center text-slate-500">
-              <svg className="w-12 h-12 mx-auto mb-3 text-slate-400" fill="currentColor" viewBox="0 0 20 20">
-                <path fillRule="evenodd" d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z" clipRule="evenodd" />
+              <svg
+                className="mx-auto mb-3 h-12 w-12 text-slate-400"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M5.05 4.05a7 7 0 119.9 9.9L10 18.9l-4.95-4.95a7 7 0 010-9.9zM10 11a2 2 0 100-4 2 2 0 000 4z"
+                  clipRule="evenodd"
+                />
               </svg>
-              <p className="text-sm">주소 정보가 없어 지도를 표시할 수 없습니다.</p>
+              <p className="text-sm">
+                주소 정보가 없어 지도를 표시할 수 없습니다.
+              </p>
             </div>
           </div>
         )}
-        {/* 안내문구 */}
         {(address || detailAddress) && (
           <div className="mt-2 text-sm text-slate-500">
-            지도에 표시된 위치를 중심으로 <span className="font-semibold text-indigo-600">반경 5km</span>가 서비스 지역입니다.
+            {' '}
+            <span className="font-semibold text-indigo-600">반경 5km</span>가 서비스 지역입니다.
           </div>
         )}
       </div>

--- a/src/types/kakao.d.ts
+++ b/src/types/kakao.d.ts
@@ -1,0 +1,28 @@
+export {};
+
+declare global {
+  interface Window {
+    kakao: {
+      maps: {
+        Map: new (container: HTMLElement, options: unknown) => unknown;
+        LatLng: new (lat: number, lng: number) => unknown;
+        Marker: new (options: unknown) => unknown;
+        InfoWindow: new (options: unknown) => unknown;
+        Circle: new (options: unknown) => unknown;
+        LatLngBounds: new () => unknown;
+        services: {
+          Geocoder: new () => {
+            addressSearch: (
+              address: string,
+              callback: (result: unknown[], status: string) => void
+            ) => void;
+          };
+          Status: {
+            OK: string;
+          };
+        };
+        load: (callback: () => void) => void;
+      };
+    };
+  }
+} 


### PR DESCRIPTION
## ✅ 작업 유형

- [x] ♻️ 리팩토링 (Refactor)

---

## 🔍 작업 내용
- 매니저 페이지 중 지도 정보를 사용하는 페이지에서 구글맵을 카카오맵으로 대체
  - 매니저 예약 상세 페이지
  - 매니저 마이페이지
  - 매니저 정보 수정 페이지

---

## 💬 리뷰요청
- 매니저 페이지에서 구글맵을 카카오맵으로 수정했습니다.
- 주소 체계가 달라져 기존 DB에 있는 구글맵 주소체계는 카카오맵에서 사용할 수 없는 문제가 있습니다.
- 위도, 경도는 소수점 13자리까지 나와 7자리까지 반올림해야하는 이슈가 있습니다.

---

## 📎 관련 이슈
Closes #154 

