### PR TITLE
fix : 예약 조회시 매니저명 버그 수정

### DIFF
--- a/src/features/customer/api/CustomerReservation.ts
+++ b/src/features/customer/api/CustomerReservation.ts
@@ -76,8 +76,8 @@ export const getCustomerReservations = async (
       queryParams.append('reservationStatus', status)
     })
   }
-  if (searchCond.managerName) {
-    queryParams.append('managerName', searchCond.managerName)
+  if (searchCond.managerNameKeyword) {
+    queryParams.append('managerNameKeyword', searchCond.managerNameKeyword)
   }
 
   // Pageable 파라미터들

--- a/src/features/customer/components/CustomerSidebar.tsx
+++ b/src/features/customer/components/CustomerSidebar.tsx
@@ -71,8 +71,8 @@ const CustomerSidebar: React.FC = () => {
               })
 
               // 매니저명
-              if (filters.managerName) {
-                params.set('managerName', filters.managerName)
+              if (filters.managerNameKeyword) {
+                params.set('managerNameKeyword', filters.managerNameKeyword)
               }
 
               setSearchParams(params)

--- a/src/features/customer/components/search/ReservationSearchFilter.tsx
+++ b/src/features/customer/components/search/ReservationSearchFilter.tsx
@@ -8,7 +8,7 @@ interface ReservationSearchFilterProps {
   onSearch: (filters: {
     dateRange: { start: string; end: string }
     reservationStatus: ReservationStatus[]
-    managerName: string
+    managerNameKeyword: string
   }) => void
   onReset: () => void
 }
@@ -42,6 +42,13 @@ const ReservationSearchFilter: React.FC<ReservationSearchFilterProps> = ({
     }
 
     setSelectedStatuses(newStatuses)
+    
+    // 상태 변경 시 즉시 검색 실행
+    onSearch({
+      dateRange: { start: startDate, end: endDate },
+      reservationStatus: newStatuses,
+      managerNameKeyword: managerName
+    })
   }
 
   const handleDateRangeChange = (newStartDate: string, newEndDate: string) => {
@@ -53,7 +60,7 @@ const ReservationSearchFilter: React.FC<ReservationSearchFilterProps> = ({
     onSearch({
       dateRange: { start: startDate, end: endDate },
       reservationStatus: selectedStatuses,
-      managerName
+      managerNameKeyword: managerName
     })
   }
 
@@ -124,6 +131,11 @@ const ReservationSearchFilter: React.FC<ReservationSearchFilterProps> = ({
           type="text"
           value={managerName}
           onChange={e => setManagerName(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              handleSearch()
+            }
+          }}
           placeholder="매니저명을 입력하세요"
           className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm"
         />

--- a/src/features/customer/pages/reservation/CustomerMyReservationPage.tsx
+++ b/src/features/customer/pages/reservation/CustomerMyReservationPage.tsx
@@ -43,7 +43,7 @@ export const CustomerMyReservationPage: React.FC = () => {
     reservationStatus: [] as ReservationStatus[],
     fromRequestDate: '',
     toRequestDate: '',
-    managerName: '',
+    managerNameKeyword: '',
     page: 0,
     size: 5
   })
@@ -53,14 +53,14 @@ export const CustomerMyReservationPage: React.FC = () => {
     const statuses = urlParams.getAll('status') as ReservationStatus[]
     const fromRequestDate = urlParams.get('fromRequestDate') || ''
     const toRequestDate = urlParams.get('toRequestDate') || ''
-    const managerName = urlParams.get('managerName') || ''
+    const managerNameKeyword = urlParams.get('managerNameKeyword') || ''
 
     setSearchParams(prev => ({
       ...prev,
       reservationStatus: statuses,
       fromRequestDate,
       toRequestDate,
-      managerName,
+      managerNameKeyword,
       page: 0
     }))
   }, [urlParams])
@@ -79,7 +79,7 @@ export const CustomerMyReservationPage: React.FC = () => {
                 : undefined,
             fromRequestDate: searchParams.fromRequestDate || undefined,
             toRequestDate: searchParams.toRequestDate || undefined,
-            managerName: searchParams.managerName || undefined
+            managerNameKeyword: searchParams.managerNameKeyword || undefined
           },
           {
             page: searchParams.page,
@@ -129,7 +129,7 @@ export const CustomerMyReservationPage: React.FC = () => {
                 : undefined,
             fromRequestDate: paramsToSearch.fromRequestDate || undefined,
             toRequestDate: paramsToSearch.toRequestDate || undefined,
-            managerName: paramsToSearch.managerName || undefined
+            managerNameKeyword: paramsToSearch.managerNameKeyword || undefined
           },
           {
             page: paramsToSearch.page,

--- a/src/features/customer/types/CustomerReservationType.ts
+++ b/src/features/customer/types/CustomerReservationType.ts
@@ -14,7 +14,7 @@ export interface ReservationSearchConditionType {
   fromRequestDate?: string // YYYY-MM-DD 형식
   toRequestDate?: string // YYYY-MM-DD 형식
   reservationStatus?: ReservationStatus[]
-  managerName?: string // 매니저 이름 검색
+  managerNameKeyword?: string // 매니저 이름 검색
   page: number
   size: number
 }


### PR DESCRIPTION
### 🐛 버그 설명
- 매니저명 검색시 api 호출을 하지 않음
---

### 🧪 재현 방법
- 수요자 예약 내역 페이지에서 검색이 원할하지 않음
- 검색버튼을 눌러야 가능
- 매니저명 검색 시 한글이 꺠져서 들어감
---

### 🎯 기대 동작
- 검색 조건 부분에서 클릭시 바로 검색 바로 호출
- 매니저명 검색 시 해당하는 매니저명만 응답
---
